### PR TITLE
Implement login blocker and persistent login

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,12 +1,15 @@
 import React, { useState } from 'react';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { createStackNavigator } from '@react-navigation/stack';
 import { NavigationContainer } from '@react-navigation/native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import UserContext from './src/contexts/UserContext';
 import HomeRoute from './src/routes/HomeRoute';
 import SettingsRoute from './src/routes/SettingsRoute';
+import LoginScreen from './src/screens/LoginScreen';
 
 const Tab = createBottomTabNavigator();
+const Stack = createStackNavigator();
 
 export default function App() {
     const [user, setUser] = useState(null);
@@ -15,10 +18,16 @@ export default function App() {
         <UserContext.Provider value={{ user, setUser }}>
             <SafeAreaProvider>
                 <NavigationContainer>
-                    <Tab.Navigator screenOptions={{ headerShown: false }}>
-                        <Tab.Screen name="Home" component={HomeRoute} />
-                        <Tab.Screen name="Settings" component={SettingsRoute} />
-                    </Tab.Navigator>
+                    {user ? (
+                        <Tab.Navigator screenOptions={{ headerShown: false }}>
+                            <Tab.Screen name="Home" component={HomeRoute} />
+                            <Tab.Screen name="Settings" component={SettingsRoute} />
+                        </Tab.Navigator>
+                    ) : (
+                        <Stack.Navigator screenOptions={{ headerShown: false }}>
+                            <Stack.Screen name="Login" component={LoginScreen} />
+                        </Stack.Navigator>
+                    )}
                 </NavigationContainer>
             </SafeAreaProvider>
         </UserContext.Provider>

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "eject": "expo eject"
   },
   "dependencies": {
+    "@react-native-async-storage/async-storage": "~1.15.0",
     "@react-navigation/bottom-tabs": "^6.0.9",
     "@react-navigation/native": "^6.0.6",
     "@react-navigation/stack": "^6.0.11",

--- a/src/AppStyle.js
+++ b/src/AppStyle.js
@@ -11,11 +11,12 @@ const classes = StyleSheet.create({
     }
 });
 
-export default {
+const AppStyle = {
     classes,
     colors: {
         maize,
         blue
     }
 };
+export default AppStyle;
 

--- a/src/api.js
+++ b/src/api.js
@@ -1,5 +1,5 @@
-// const API_URL = "http://ec2-18-118-95-190.us-east-2.compute.amazonaws.com:3000";
-const API_URL = "http://localhost:3000";
+const API_URL = "http://ec2-18-118-95-190.us-east-2.compute.amazonaws.com:3000";
+// const API_URL = "http://localhost:3000";
 
 const request = async (endpoint, body, headers = {}) => {
     const res = await fetch(API_URL + endpoint, {

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity } from 'react-native';
+import AppStyle from '../AppStyle';
+
+const styles = StyleSheet.create({
+    baseButton: {
+        borderWidth: 2,
+        borderRadius: 10,
+        borderColor: AppStyle.colors.blue,
+        padding: 10
+    },
+    filled: {
+        backgroundColor: AppStyle.colors.blue
+    },
+    text: {
+        textAlign: 'center'
+    }
+});
+
+const Button = ({ label, filled, wide, onPress }) => {
+    return (
+        <TouchableOpacity onPress={onPress} style={[styles.baseButton, filled && styles.filled]}>
+            <Text styles={[styles.text, { color: 'white' }]}>{label}</Text>
+        </TouchableOpacity>
+    );
+};
+
+export default Button;

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -7,7 +7,7 @@ const styles = StyleSheet.create({
         borderWidth: 3,
         borderRadius: 8,
         borderColor: AppStyle.colors.blue,
-        padding: 5
+        padding: 8
     },
     filled: {
         backgroundColor: AppStyle.colors.blue
@@ -15,6 +15,9 @@ const styles = StyleSheet.create({
     disabled: {
         backgroundColor: 'gray',
         borderColor: 'gray'
+    },
+    wide: {
+        width: '100%'
     },
     text: {
         textAlign: 'center',
@@ -26,7 +29,7 @@ const Button = ({ label, filled, wide, onPress, disabled }) => {
     return (
         <TouchableOpacity
             onPress={onPress}
-            style={[styles.baseButton, filled && styles.filled, disabled && styles.disabled]}
+            style={[styles.baseButton, filled && styles.filled, disabled && styles.disabled, wide && styles.wide]}
             disabled={disabled}
         >
             <Text style={[styles.text, (filled || disabled) && { color: 'white' }]}>{label}</Text>

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -4,23 +4,32 @@ import AppStyle from '../AppStyle';
 
 const styles = StyleSheet.create({
     baseButton: {
-        borderWidth: 2,
-        borderRadius: 10,
+        borderWidth: 3,
+        borderRadius: 8,
         borderColor: AppStyle.colors.blue,
-        padding: 10
+        padding: 5
     },
     filled: {
         backgroundColor: AppStyle.colors.blue
     },
+    disabled: {
+        backgroundColor: 'gray',
+        borderColor: 'gray'
+    },
     text: {
-        textAlign: 'center'
+        textAlign: 'center',
+        color: AppStyle.colors.blue
     }
 });
 
-const Button = ({ label, filled, wide, onPress }) => {
+const Button = ({ label, filled, wide, onPress, disabled }) => {
     return (
-        <TouchableOpacity onPress={onPress} style={[styles.baseButton, filled && styles.filled]}>
-            <Text styles={[styles.text, { color: 'white' }]}>{label}</Text>
+        <TouchableOpacity
+            onPress={onPress}
+            style={[styles.baseButton, filled && styles.filled, disabled && styles.disabled]}
+            disabled={disabled}
+        >
+            <Text style={[styles.text, (filled || disabled) && { color: 'white' }]}>{label}</Text>
         </TouchableOpacity>
     );
 };

--- a/src/components/LogInOrOutButton.jsx
+++ b/src/components/LogInOrOutButton.jsx
@@ -1,7 +1,7 @@
 import React, { useContext, useState } from 'react';
-import { Button } from 'react-native';
 import UserContext from '../contexts/UserContext';
 import useGoogleLogin from '../hooks/useGoogleLogin';
+import Button from './Button';
 
 /**
  * A button that shows "Log In" if no one is logged in, or "Log Out"
@@ -25,8 +25,9 @@ const LogInOrOutButton = ({ onError = console.log }) => {
     return (
         <Button
             disabled={awaitingLogin || !isReady}
-            title={user ? "Log Out" : "Log In"}
+            label={user ? "Log Out" : "Log In"}
             onPress={user ? logOut : logIn}
+            filled
         />
     );
 };

--- a/src/components/LogInOrOutButton.jsx
+++ b/src/components/LogInOrOutButton.jsx
@@ -1,30 +1,35 @@
 import React, { useContext, useState } from 'react';
 import UserContext from '../contexts/UserContext';
 import useGoogleLogin from '../hooks/useGoogleLogin';
+import useSavedAccessToken from '../hooks/useSavedAccessToken';
 import Button from './Button';
 
 /**
  * A button that shows "Log In" if no one is logged in, or "Log Out"
  * otherwise, and logs in/out the user on press.
  */
-const LogInOrOutButton = ({ onError = console.log, ...props }) => {
+const LogInOrOutButton = ({ onError = console.log, disabled, ...props }) => {
     const logIn = () => {
         setAwaitingLogin(true);
         startLogin();
     };
-    const logOut = () => setUser(null);
+    const logOut = async () => {
+        await saveAccessToken("");
+        setUser(null);
+    }
     const handleLoginFinish = (newUser, error) => {
         setAwaitingLogin(false);
         if (error) onError(error);
     }
 
+    const { saveAccessToken } = useSavedAccessToken();
     const { isReady, startLogin } = useGoogleLogin(handleLoginFinish);
     const { user, setUser } = useContext(UserContext);
     const [awaitingLogin, setAwaitingLogin] = useState(false);
 
     return (
         <Button
-            disabled={awaitingLogin || !isReady}
+            disabled={disabled || awaitingLogin || !isReady}
             label={user ? "Log Out" : "Log In"}
             onPress={user ? logOut : logIn}
             filled

--- a/src/components/LogInOrOutButton.jsx
+++ b/src/components/LogInOrOutButton.jsx
@@ -7,7 +7,7 @@ import Button from './Button';
  * A button that shows "Log In" if no one is logged in, or "Log Out"
  * otherwise, and logs in/out the user on press.
  */
-const LogInOrOutButton = ({ onError = console.log }) => {
+const LogInOrOutButton = ({ onError = console.log, ...props }) => {
     const logIn = () => {
         setAwaitingLogin(true);
         startLogin();
@@ -28,6 +28,7 @@ const LogInOrOutButton = ({ onError = console.log }) => {
             label={user ? "Log Out" : "Log In"}
             onPress={user ? logOut : logIn}
             filled
+            {...props}
         />
     );
 };

--- a/src/hooks/useGoogleLogin.js
+++ b/src/hooks/useGoogleLogin.js
@@ -3,6 +3,7 @@ import * as Google from 'expo-auth-session/providers/google';
 import * as WebBrowser from 'expo-web-browser';
 import { logInOrSignUp } from '../api';
 import UserContext from '../contexts/UserContext';
+import useSavedAccessToken from './useSavedAccessToken';
 
 WebBrowser.maybeCompleteAuthSession();
 
@@ -15,10 +16,12 @@ const useGoogleLogin = (loginCallback = () => { }) => {
     });
 
     const { setUser } = useContext(UserContext);
+    const { saveAccessToken } = useSavedAccessToken();
 
     const returnUserInfo = async (accessToken) => {
         try {
             const user = await logInOrSignUp(accessToken);
+            await saveAccessToken(accessToken);
             loginCallback(user);
             setUser(user);
         } catch (e) {

--- a/src/hooks/useGoogleLogin.js
+++ b/src/hooks/useGoogleLogin.js
@@ -27,11 +27,14 @@ const useGoogleLogin = (loginCallback = () => { }) => {
     }
 
     useEffect(() => {
+        if (!response) return;
         if (response?.type === 'success') {
             const { authentication } = response;
             returnUserInfo(authentication.accessToken);
         } else {
             console.log(response);
+            if (response.type === 'dismiss') loginCallback(null, new Error("User cancelled login"));
+            else loginCallback(null, new Error("Something went wrong, please try again"));
         }
     }, [response]);
 

--- a/src/hooks/useSavedAccessToken.js
+++ b/src/hooks/useSavedAccessToken.js
@@ -1,0 +1,28 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useEffect, useState } from 'react';
+
+const tokenKey = "@ACCESS_TOKEN";
+
+const useSavedAccessToken = () => {
+    const [accessToken, setAccessToken] = useState(null);
+
+    const getAccessToken = async () => {
+        const token = await AsyncStorage.getItem(tokenKey);
+        setAccessToken(token);
+    }
+
+    useEffect(() => {
+        getAccessToken();
+    }, []);
+
+    const saveAccessToken = async (token) => {
+        await AsyncStorage.setItem(tokenKey, token);
+    }
+
+    return {
+        accessToken,
+        saveAccessToken
+    };
+};
+
+export default useSavedAccessToken;

--- a/src/screens/HomeScreen.jsx
+++ b/src/screens/HomeScreen.jsx
@@ -1,18 +1,12 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { Text, View } from 'react-native';
-import LogInOrOutButton from '../components/LogInOrOutButton';
-import UserContext from '../contexts/UserContext';
 
 const HomeScreen = () => {
-    const { user } = useContext(UserContext);
-
     return (
         <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
             <Text>
-                {user ? `Logged in as ${user.firstName} ${user.lastName}` :
-                    "Log in with your UMich Google account:"}
+                This is home screen hello
             </Text>
-            <LogInOrOutButton />
         </View>
     );
 };

--- a/src/screens/HomeScreen.jsx
+++ b/src/screens/HomeScreen.jsx
@@ -1,12 +1,17 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { Text, View } from 'react-native';
+import LogInOrOutButton from '../components/LogInOrOutButton';
+import UserContext from '../contexts/UserContext';
 
 const HomeScreen = () => {
+    const { user } = useContext(UserContext);
+
     return (
         <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-            <Text>
-                This is home screen hello
+            <Text style={{ marginBottom: 20 }}>
+                Hello this is home screen. You are logged in as {user.firstName} {user.lastName}
             </Text>
+            <LogInOrOutButton filled={false} />
         </View>
     );
 };

--- a/src/screens/LoginScreen.jsx
+++ b/src/screens/LoginScreen.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import Button from '../components/Button';
+import LogInOrOutButton from '../components/LogInOrOutButton';
+
+const styles = StyleSheet.create({
+    screen: {
+        flex: 1,
+        alignItems: 'center',
+        justifyContent: 'center'
+    }
+})
+
+const LoginScreen = () => {
+    return (
+        <View style={styles.screen}>
+            <Text>Log in to your UMich account:</Text>
+            <LogInOrOutButton />
+        </View>
+    );
+};
+
+export default LoginScreen;

--- a/src/screens/LoginScreen.jsx
+++ b/src/screens/LoginScreen.jsx
@@ -1,7 +1,10 @@
-import React from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
+import { logInOrSignUp } from '../api';
 import AppStyle from '../AppStyle';
 import LogInOrOutButton from '../components/LogInOrOutButton';
+import UserContext from '../contexts/UserContext';
+import useSavedAccessToken from '../hooks/useSavedAccessToken';
 
 const styles = StyleSheet.create({
     screen: {
@@ -16,12 +19,30 @@ const styles = StyleSheet.create({
 })
 
 const LoginScreen = () => {
+    const [ready, setReady] = useState(false);
+    const { setUser } = useContext(UserContext);
+    const { accessToken } = useSavedAccessToken();
+
+    const tryAccessToken = async () => {
+        const user = await logInOrSignUp(accessToken);
+        if (user.result !== "error") {
+            setUser(user);
+        } else setReady(true);
+    };
+
+    useEffect(() => {
+        if (accessToken) {
+            setReady(false);
+            tryAccessToken();
+        } else setReady(true);
+    }, [accessToken]);
+
     return (
         <View style={styles.screen}>
             <Text style={[AppStyle.classes.header, styles.center]}>Welcome to MaizExchange</Text>
             <Text style={[styles.center, { marginBottom: 8 }]}>Please log in with your U-M Google account:</Text>
             <View style={{ width: '80%', maxWidth: 300 }}>
-                <LogInOrOutButton wide />
+                <LogInOrOutButton wide disabled={!ready} />
             </View>
         </View>
     );

--- a/src/screens/LoginScreen.jsx
+++ b/src/screens/LoginScreen.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
-import Button from '../components/Button';
+import AppStyle from '../AppStyle';
 import LogInOrOutButton from '../components/LogInOrOutButton';
 
 const styles = StyleSheet.create({
@@ -8,14 +8,21 @@ const styles = StyleSheet.create({
         flex: 1,
         alignItems: 'center',
         justifyContent: 'center'
+    },
+    center: {
+        textAlign: 'center',
+        marginBottom: 20
     }
 })
 
 const LoginScreen = () => {
     return (
         <View style={styles.screen}>
-            <Text>Log in to your UMich account:</Text>
-            <LogInOrOutButton />
+            <Text style={[AppStyle.classes.header, styles.center]}>Welcome to MaizExchange</Text>
+            <Text style={[styles.center, { marginBottom: 8 }]}>Please log in with your U-M Google account:</Text>
+            <View style={{ width: '80%', maxWidth: 300 }}>
+                <LogInOrOutButton wide />
+            </View>
         </View>
     );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1256,6 +1256,13 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@react-native-async-storage/async-storage@~1.15.0":
+  version "1.15.17"
+  resolved "https://registry.yarnpkg.com/@react-native-async-storage/async-storage/-/async-storage-1.15.17.tgz#0dae263a52e476ffce871086f1fef5b8e44708eb"
+  integrity sha512-NQCFs47aFEch9kya/bqwdpvSdZaVRtzU7YB02L8VrmLSLpKgQH/1VwzFUBPcc1/JI1s3GU4yOLVrEbwxq+Fqcw==
+  dependencies:
+    merge-options "^3.0.4"
+
 "@react-native-community/cli-debugger-ui@^5.0.1":
   version "5.0.1"
   resolved "https://registry.npmjs.org/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-5.0.1.tgz"
@@ -3250,6 +3257,11 @@ is-plain-obj@^1.0.0:
   resolved "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
 
+is-plain-obj@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
+  integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
+
 is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz"
@@ -3686,6 +3698,13 @@ md5-file@^3.2.3:
   integrity sha512-3Tkp1piAHaworfcCgH0jKbTvj1jWWFgbvh2cXaNCgHwyTCBxxvD1Y04rmfpvdPm1P4oXMOpm6+2H7sr7v9v8Fw==
   dependencies:
     buffer-alloc "^1.1.0"
+
+merge-options@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/merge-options/-/merge-options-3.0.4.tgz#84709c2aa2a4b24c1981f66c179fe5565cc6dbb7"
+  integrity sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==
+  dependencies:
+    is-plain-obj "^2.1.0"
 
 merge-stream@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Things that this PR addresses:

- Implements the preliminary login flow as discussed earlier this week, blocking out users until they can log in
- Saves user access tokens across sessions, allowing users to remain logged in after restarting the app
- Adds a reusable custom button component with a few different options for styling, such as `filled`, `wide`, `disabled`, etc.

To test this PR:

- Use the full login/logout flow, make sure it works as expected
- Refresh the page/reload the app at each step to make sure your login state is persisted