### PR TITLE
Finish "New Listing" flow

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,7 +1,11 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
 const API_URL = "http://ec2-18-118-95-190.us-east-2.compute.amazonaws.com:3000";
 // const API_URL = "http://localhost:3000";
 
 const request = async (endpoint, body, headers = {}) => {
+    const token = await AsyncStorage.getItem("@ACCESS_TOKEN");
+    if (token) headers["Authorization"] = token;
     const res = await fetch(API_URL + endpoint, {
         method: body ? 'POST' : 'GET',
         body: body ? JSON.stringify(body) : undefined,
@@ -21,4 +25,16 @@ export const testApi = async () => {
 
 export const logInOrSignUp = async (accessToken) => {
     return request('/auth/logInOrSignUp', { accessToken });
+}
+
+export const postListing = async ({
+    title,
+    price,
+    type,
+    category,
+    description
+}) => {
+    return request('/listings', {
+        title, price, type, category, description
+    });
 }

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -5,12 +5,9 @@ import AppStyle from '../AppStyle';
 const styles = StyleSheet.create({
     baseButton: {
         borderWidth: 3,
-        borderRadius: 8,
+        borderRadius: 5,
         borderColor: AppStyle.colors.blue,
         padding: 8
-    },
-    filled: {
-        backgroundColor: AppStyle.colors.blue
     },
     disabled: {
         backgroundColor: 'gray',
@@ -25,14 +22,29 @@ const styles = StyleSheet.create({
     }
 });
 
-const Button = ({ label, filled, wide, onPress, disabled }) => {
+const Button = ({ label, icon, filled, wide, onPress, disabled, bold, color = "blue" }) => {
+    const c = AppStyle.colors[color];
+
     return (
         <TouchableOpacity
             onPress={onPress}
-            style={[styles.baseButton, filled && styles.filled, disabled && styles.disabled, wide && styles.wide]}
+            style={[
+                styles.baseButton,
+                { borderColor: c },
+                filled && { backgroundColor: c },
+                disabled && styles.disabled,
+                wide && styles.wide
+            ]}
             disabled={disabled}
         >
-            <Text style={[styles.text, (filled || disabled) && { color: 'white' }]}>{label}</Text>
+            <Text style={[
+                styles.text,
+                ((filled && color === "blue") || disabled) && { color: 'white' },
+                bold && { fontWeight: "bold" }
+            ]}>
+                {icon ? icon : null}
+                {label}
+            </Text>
         </TouchableOpacity>
     );
 };

--- a/src/components/Dropdown.jsx
+++ b/src/components/Dropdown.jsx
@@ -1,0 +1,69 @@
+import React, { useState } from "react";
+import {
+    View,
+    Text,
+    LayoutAnimation,
+    StyleSheet,
+    UIManager,
+    Platform
+} from "react-native";
+import { TouchableOpacity } from "react-native-gesture-handler";
+import Icon from 'react-native-vector-icons/Ionicons';
+
+if (
+    Platform.OS === "android" &&
+    UIManager.setLayoutAnimationEnabledExperimental
+) {
+    UIManager.setLayoutAnimationEnabledExperimental(true);
+}
+
+const Dropdown = ({ title, children, onToggle = () => false, topBorder }) => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    const toggleOpen = () => {
+        onToggle(!isOpen);
+        setIsOpen(value => !value);
+        LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+    };
+
+    return (
+        <>
+            {topBorder && (
+                <View style={{ alignItems: 'center' }} ><View style={styles.divider} /></View>
+            )}
+            <TouchableOpacity onPress={toggleOpen} style={styles.heading} activeOpacity={0.6}>
+                {typeof title === "string" ? (
+                    <Text style={styles.title}>{title}</Text>
+                ) : title}
+                <Icon name={isOpen ? "chevron-up-outline" : "chevron-down-outline"} size={18} color="black" />
+            </TouchableOpacity>
+            <View style={[styles.list, !isOpen ? styles.hidden : undefined]}>
+                {children}
+            </View>
+            <View style={{ alignItems: 'center' }} ><View style={styles.divider} /></View>
+        </>
+    );
+};
+
+const styles = StyleSheet.create({
+    heading: {
+        alignItems: "center",
+        flexDirection: "row",
+        justifyContent: "space-between",
+        marginVertical: 10,
+        paddingHorizontal: 20
+    },
+    hidden: {
+        height: 0,
+    },
+    list: {
+        overflow: 'hidden'
+    },
+    divider: {
+        borderBottomColor: 'grey',
+        borderBottomWidth: StyleSheet.hairlineWidth,
+        width: '100%',
+    },
+});
+
+export default Dropdown;

--- a/src/routes/NewListingRoute.jsx
+++ b/src/routes/NewListingRoute.jsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import { createStackNavigator } from '@react-navigation/stack';
 import NewListingScreen from '../screens/NewListingScreen';
+import NewListingPopup from '../screens/NewListingPopup';
 
 const Stack = createStackNavigator();
 
 const NewListingRoute = () => (
     <Stack.Navigator>
         <Stack.Screen name="New Listing" component={NewListingScreen} />
+        <Stack.Screen name="Listing Form" component={NewListingPopup} options={{ presentation: 'modal' }} />
     </Stack.Navigator>
 );
 

--- a/src/screens/NewListingPopup.jsx
+++ b/src/screens/NewListingPopup.jsx
@@ -47,14 +47,10 @@ const NewListingPopup = ({ navigation, route }) => {
     }
 
     const submitDisabled = !price || !title || waiting;
-    const typeRender = type === "other" ? categoryLabel : type;
 
     return (
         <ScrollView style={styles.rootContainer} keyboardShouldPersistTaps="handled" scrollEnabled={false}>
-            <Text style={[AppStyle.classes.header, styles.caps]}>Selling {typeRender}</Text>
-            {type !== "other" && (
-                <Text style={[styles.caps, { marginTop: 10 }]}>Category: {categoryLabel}</Text>
-            )}
+            <Text style={[AppStyle.classes.header, styles.caps]}>Selling {categoryLabel} {type !== "other" && type}</Text>
 
             <Text style={styles.sectionheaders}>
                 {type === "ticket" ? "Opponent Name" : "Item Name"}

--- a/src/screens/NewListingPopup.jsx
+++ b/src/screens/NewListingPopup.jsx
@@ -1,0 +1,126 @@
+import React, { useState } from 'react';
+import { Keyboard, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
+import { postListing } from '../api';
+import AppStyle from '../AppStyle';
+import Button from '../components/Button';
+
+const NewListingPopup = ({ navigation, route }) => {
+    const [title, setTitle] = useState('');
+    const [price, setPrice] = useState('');
+    const [description, setDescription] = useState('');
+    const [waiting, setWaiting] = useState(false);
+
+    const { category, type } = route.params;
+
+    const processPriceInput = p => {
+        p = p.replace("$", "").replace(" ", "");
+        setPrice(p);
+    };
+
+    const onPriceBlur = () => {
+        const roundedPrice = parseFloat(price).toFixed(2);
+        if (roundedPrice === "NaN") return "";
+        setPrice(roundedPrice);
+        return roundedPrice;
+    };
+
+    const onSubmit = async () => {
+        setWaiting(true);
+        const finalPrice = onPriceBlur();
+        Keyboard.dismiss();
+        await postListing({
+            title,
+            price: parseFloat(finalPrice),
+            category,
+            type,
+            description
+        });
+        setWaiting(false);
+        navigation.goBack();
+        // TODO: Better feedback that the posting was listed
+    }
+
+    const submitDisabled = !price || !title || waiting;
+    const typeRender = type === "other" ? category : type;
+
+    return (
+        <ScrollView style={styles.rootContainer} keyboardShouldPersistTaps="handled" scrollEnabled={false}>
+            <Text style={[AppStyle.classes.header, styles.caps]}>Selling {typeRender}</Text>
+            {type !== "other" && (
+                <Text style={[styles.caps, { marginTop: 10 }]}>Category: {category}</Text>
+            )}
+
+            <Text style={styles.sectionheaders}>
+                {type === "ticket" ? "Opponent Name" : "Item Name"}
+            </Text>
+            <TextInput
+                style={styles.textfields}
+                value={title}
+                onChangeText={setTitle}
+            />
+
+            <View>
+                <Text style={styles.sectionheaders}>Price</Text>
+            </View>
+            <TextInput
+                style={[styles.textfields, { width: 100 }]}
+                value={"$ " + price}
+                keyboardType='numeric'
+                onChangeText={processPriceInput}
+                onBlur={onPriceBlur}
+                maxLength={8}
+
+            />
+
+            {type !== "ticket" && (
+                <>
+                    <Text style={styles.sectionheaders}>Notes</Text>
+                    <TextInput
+                        style={[styles.textfields, { height: 80 }]}
+                        value={description}
+                        placeholder="Describe the item you're selling..."
+                        onChangeText={setDescription}
+                        multiline
+                    />
+                </>
+            )}
+
+            <View style={styles.buttonWrapper}>
+                <Button label="Post Listing" wide filled bold onPress={onSubmit} disabled={submitDisabled} />
+            </View>
+        </ScrollView>
+    );
+};
+
+const styles = StyleSheet.create({
+    rootContainer: {
+        marginTop: 15,
+        marginLeft: 15
+    },
+    sectionheaders: {
+        fontSize: 12,
+        fontWeight: "900",
+        marginTop: 16,
+        marginBottom: 4,
+        marginLeft: 8,
+    },
+    textfields: {
+        height: 40,
+        width: '85%',
+        borderColor: '#00274C',
+        borderWidth: 1,
+        //backgroundColor: '#D3D3D3', 
+        padding: 4,
+        textShadowColor: 'rgba(0, 0, 0, 0.75)',
+        marginLeft: 8,
+    },
+    buttonWrapper: {
+        marginHorizontal: '10%',
+        marginTop: 15
+    },
+    caps: {
+        textTransform: 'capitalize'
+    }
+})
+
+export default NewListingPopup;

--- a/src/screens/NewListingPopup.jsx
+++ b/src/screens/NewListingPopup.jsx
@@ -10,7 +10,13 @@ const NewListingPopup = ({ navigation, route }) => {
     const [description, setDescription] = useState('');
     const [waiting, setWaiting] = useState(false);
 
-    const { category, type } = route.params;
+    const {
+        category: {
+            label: categoryLabel,
+            value: categoryValue
+        },
+        type
+    } = route.params;
 
     const processPriceInput = p => {
         p = p.replace("$", "").replace(" ", "");
@@ -31,7 +37,7 @@ const NewListingPopup = ({ navigation, route }) => {
         await postListing({
             title,
             price: parseFloat(finalPrice),
-            category,
+            category: categoryValue,
             type,
             description
         });
@@ -41,13 +47,13 @@ const NewListingPopup = ({ navigation, route }) => {
     }
 
     const submitDisabled = !price || !title || waiting;
-    const typeRender = type === "other" ? category : type;
+    const typeRender = type === "other" ? categoryLabel : type;
 
     return (
         <ScrollView style={styles.rootContainer} keyboardShouldPersistTaps="handled" scrollEnabled={false}>
             <Text style={[AppStyle.classes.header, styles.caps]}>Selling {typeRender}</Text>
             {type !== "other" && (
-                <Text style={[styles.caps, { marginTop: 10 }]}>Category: {category}</Text>
+                <Text style={[styles.caps, { marginTop: 10 }]}>Category: {categoryLabel}</Text>
             )}
 
             <Text style={styles.sectionheaders}>

--- a/src/screens/NewListingScreen.jsx
+++ b/src/screens/NewListingScreen.jsx
@@ -1,129 +1,84 @@
-import React, { useState } from 'react';
-import { Text, View, StyleSheet, TextInput, ScrollView } from 'react-native';
-import { Button } from 'react-native-paper';
+import React from 'react';
+import { Text, View, StyleSheet, ScrollView } from 'react-native';
 import EnIcon from 'react-native-vector-icons/Entypo';
+import MCIcon from 'react-native-vector-icons/MaterialCommunityIcons';
 import AppStyle from '../AppStyle';
+import Button from '../components/Button';
 import Dropdown from '../components/Dropdown';
 
-const categories = [
-    { label: "Ticket", value: "ticket", icon: "ticket" },
-    { label: "Textbook", value: "textbook", icon: "book" },
-    { label: "Other/Misc.", value: "other", icon: "box" }
+const types = [
+    {
+        label: "Ticket", value: "ticket", icon: "ticket", options: [
+            { label: "Football", value: "football", icon: "football" },
+            { label: "Basketball", value: "basketball", icon: "basketball" },
+            { label: "Hockey", value: "hockey", icon: "hockey-puck" }
+        ]
+    },
+    {
+        label: "Textbook", value: "textbook", icon: "book", options: [
+            { label: "Mathematics", value: "math", icon: "book-open-page-variant" },
+            { label: "History", value: "history", icon: "book-open-page-variant" },
+            { label: "Science", value: "science", icon: "book-open-page-variant" },
+            { label: "Foreign Language", value: "language", icon: "book-open-page-variant" }
+        ]
+    },
+    {
+        label: "Other/Misc.", value: "other", icon: "box", options: [
+            { label: "Sublease", value: "sublease", icon: "file-document-outline" },
+            { label: "Parking Spot", value: "parking", icon: "car" },
+            { label: "Electronics", value: "electronics", icon: "laptop" },
+            { label: "Other Object", value: "object", icon: "cube-outline" }
+        ]
+    }
 ];
 
-const NewListingScreen = () => {
-    const [checked, setChecked] = useState('');
-    const [description, setDescription] = useState('');
-    const [category, setCategory] = useState('');
-    const [price, setPrice] = useState('');
-
-    const press = () => {
-        alert('button pressed');
-        alert(description);
-        setDescription('');
-        setChecked("first");
-        setCategory('');
-        setPrice(0);
-    }
-
-    const Category = () => {
-        return (
-            <View style={styles.categories}>
-                <Text>Category</Text>
-                <TextInput
-                    style={styles.categoryfields}
-                    value={category}
-                    onChangeText={setCategory}
-                    placeholder="Category"
-                />
-            </View>
-        );
-    };
-
+const NewListingScreen = ({ navigation }) => {
     return (
         <ScrollView>
-            <Text style={AppStyle.classes.header}>
+            <Text style={[AppStyle.classes.header, { marginHorizontal: 10, marginVertical: 20 }]}>
                 What would you like to sell?
             </Text>
-            <Text style={styles.sectionheaders}>Add Description</Text>
-            <TextInput
-                style={styles.textfields}
-                value={description}
-                placeholder="Description"
-                onChangeText={setDescription}
-            />
 
             <Text style={styles.sectionheaders}>Type</Text>
             {
-                categories.map((cat, i) => (
+                types.map((type, i) => (
                     <Dropdown
                         topBorder={i === 0}
                         title={(
                             <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-                                <EnIcon name={cat.icon} size={16} color="black" style={{ marginRight: 5 }} />
-                                <Text>{cat.label}</Text>
+                                <EnIcon name={type.icon} size={26} color="black" style={{ marginRight: 10 }} />
+                                <Text style={{ fontSize: 18, paddingVertical: 10 }}>{type.label}</Text>
                             </View>
                         )}
                     >
-                        <Category />
+                        {type.options.map(cat => (
+                            <View style={styles.buttonWrapper}>
+                                <Button
+                                    label={"  " + cat.label}
+                                    icon={<MCIcon name={cat.icon} size={18} color="white" />}
+                                    filled
+                                    bold
+                                    onPress={() =>
+                                        navigation.navigate("Listing Form", { category: cat.value, type: type.value })
+                                    }
+                                />
+                            </View>
+                        ))}
+                        <View style={{ width: '100%', height: 20 }} />
                     </Dropdown>
                 ))
             }
-
-            {/*<View style={styles.radiobutton}><Text>Other</Text><RadioButton
-                value="third"
-                status={checked === 'third' ? 'checked' : 'unchecked'}
-                onPress={() => setChecked('third')}
-                color="#00274C"
-                uncheckedColor='#EAE8E4'
-        /></View>*/}
-
-            <View>
-                <Text style={styles.sectionheaders}>Price</Text>
-            </View>
-            <TextInput
-                style={styles.textfields}
-                value={price}
-                keyboardType='numeric'
-                onChangeText={setPrice}
-                placeholder="$$"
-                maxLength={10}
-            />
-
-            <View style={styles.buttonboi}>
-                <Button onPress={press} icon="card-plus" mode="contained" color="#FFCB05">
-                    Create Listing
-                </Button>
-            </View>
         </ScrollView>
     );
 }
 
 const styles = StyleSheet.create({
-    radiobutton: {
-        flexDirection: 'row',
-        width: '100%',
-        height: 70,
-        borderTopWidth: 1,
-        padding: 8,
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        color: '#EAE8E4',
-    },
     sectionheaders: {
         fontSize: 12,
         fontWeight: "900",
         marginTop: 16,
         marginBottom: 4,
         marginLeft: 8,
-    },
-    categories: {
-        paddingLeft: 32,
-        fontSize: 10,
-        fontWeight: '200',
-        marginTop: 16,
-        marginBottom: 16,
-        width: '75%',
     },
     textfields: {
         height: 40,
@@ -135,18 +90,11 @@ const styles = StyleSheet.create({
         textShadowColor: 'rgba(0, 0, 0, 0.75)',
         marginLeft: 8,
     },
-    categoryfields: {
-        height: 40,
-        width: '100%',
-        borderColor: '#00274C',
-        borderWidth: 1,
-        //backgroundColor: '#D3D3D3', 
-        padding: 4,
-        textShadowColor: 'rgba(0, 0, 0, 0.75)',
-        marginLeft: 8,
-    },
-    buttonboi: {
-        margin: 16,
+    buttonWrapper: {
+        width: '50%',
+        marginVertical: 5,
+        marginLeft: 'auto',
+        marginRight: 'auto'
     }
 });
 

--- a/src/screens/NewListingScreen.jsx
+++ b/src/screens/NewListingScreen.jsx
@@ -1,24 +1,25 @@
-import React, { useContext } from 'react';
+import React, { useState } from 'react';
 import { Text, View, StyleSheet, TextInput, ScrollView } from 'react-native';
-import UserContext from '../contexts/UserContext';
-import { RadioButton, Button } from 'react-native-paper';
-import { isSearchBarAvailableForCurrentPlatform } from 'react-native-screens';
+import { Button } from 'react-native-paper';
+import EnIcon from 'react-native-vector-icons/Entypo';
+import AppStyle from '../AppStyle';
+import Dropdown from '../components/Dropdown';
 
+const categories = [
+    { label: "Ticket", value: "ticket", icon: "ticket" },
+    { label: "Textbook", value: "textbook", icon: "book" },
+    { label: "Other/Misc.", value: "other", icon: "box" }
+];
 
 const NewListingScreen = () => {
-    const { user } = useContext(UserContext);
-    const [checked, setChecked] = React.useState('');
-    const [description, setDescription] = React.useState('');
-    const [category, setCategory] = React.useState('');
-    const [price, setPrice] = React.useState('');
+    const [checked, setChecked] = useState('');
+    const [description, setDescription] = useState('');
+    const [category, setCategory] = useState('');
+    const [price, setPrice] = useState('');
 
-    const text = "test";
     const press = () => {
         alert('button pressed');
         alert(description);
-        alert(checked);
-        alert(category);
-        alert(price);
         setDescription('');
         setChecked("first");
         setCategory('');
@@ -28,73 +29,59 @@ const NewListingScreen = () => {
     const Category = () => {
         return (
             <View style={styles.categories}>
-            <Text>Category</Text>
-            <TextInput 
-                style={styles.categoryfields}
-                value={category}
-                onChangeText={setCategory}
-                placeholder="Category"
-    
-            />
+                <Text>Category</Text>
+                <TextInput
+                    style={styles.categoryfields}
+                    value={category}
+                    onChangeText={setCategory}
+                    placeholder="Category"
+                />
             </View>
         );
-    }
+    };
 
-    //TextInput onchange (calls function on every key stroke) & value props
-    // store value from onChange to state 
-
-    //define new state variables for each TextInput
     return (
-        <ScrollView contentContainerStyle={styles.container}>
+        <ScrollView>
+            <Text style={AppStyle.classes.header}>
+                What would you like to sell?
+            </Text>
             <Text style={styles.sectionheaders}>Add Description</Text>
-            <TextInput 
+            <TextInput
                 style={styles.textfields}
                 value={description}
                 placeholder="Description"
                 onChangeText={setDescription}
             />
-            
 
             <Text style={styles.sectionheaders}>Type</Text>
-            <View style={styles.radiobutton}><Text>Tickets</Text><RadioButton
-                value="first"
-                status={ checked === 'first' ? 'checked' : 'unchecked' }
-                onPress={() => setChecked('first')}
-                color="#00274C"
-                uncheckedColor='#EAE8E4'
-            /></View>
-
             {
-                ( checked === 'first') && Category()
+                categories.map((cat, i) => (
+                    <Dropdown
+                        topBorder={i === 0}
+                        title={(
+                            <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+                                <EnIcon name={cat.icon} size={16} color="black" style={{ marginRight: 5 }} />
+                                <Text>{cat.label}</Text>
+                            </View>
+                        )}
+                    >
+                        <Category />
+                    </Dropdown>
+                ))
             }
 
-            
-            <View style={styles.radiobutton}><Text>Textbooks</Text><RadioButton
-                value="second"
-                status={ checked === 'second' ? 'checked' : 'unchecked' }
-                onPress={() => setChecked('second')}
-                color="#00274C"
-                uncheckedColor='#EAE8E4'
-            /></View>
-
-            {   
-                ( checked === 'second') && Category()
-            }
-
-            <View style={styles.radiobutton}><Text>Other</Text><RadioButton
+            {/*<View style={styles.radiobutton}><Text>Other</Text><RadioButton
                 value="third"
-                status={ checked === 'third' ? 'checked' : 'unchecked' }
+                status={checked === 'third' ? 'checked' : 'unchecked'}
                 onPress={() => setChecked('third')}
                 color="#00274C"
                 uncheckedColor='#EAE8E4'
-            /></View>
-            {
-                ( checked === 'third') && Category()
-            }
-            
+        /></View>*/}
 
-            <Text style={styles.sectionheaders}>Price</Text>
-            <TextInput 
+            <View>
+                <Text style={styles.sectionheaders}>Price</Text>
+            </View>
+            <TextInput
                 style={styles.textfields}
                 value={price}
                 keyboardType='numeric'
@@ -102,29 +89,20 @@ const NewListingScreen = () => {
                 placeholder="$$"
                 maxLength={10}
             />
-            
-            <View style={styles.buttonboi}><Button onPress={press} icon="card-plus" mode="contained" color="#FFCB05">
-                Create Listing
-            </Button></View>
-            
+
+            <View style={styles.buttonboi}>
+                <Button onPress={press} icon="card-plus" mode="contained" color="#FFCB05">
+                    Create Listing
+                </Button>
+            </View>
         </ScrollView>
-        
     );
 }
 
 const styles = StyleSheet.create({
-    container: {
-        flex: 1,
-        backgroundColor: '#fff',
-        alignItems: 'flex-start',
-        justifyContent: 'center',
-        //width: '50%',
-        //marginLeft: '25%',
-    },
-
     radiobutton: {
-        flexDirection: 'row', 
-        width: '100%', 
+        flexDirection: 'row',
+        width: '100%',
         height: 70,
         borderTopWidth: 1,
         padding: 8,
@@ -132,7 +110,6 @@ const styles = StyleSheet.create({
         justifyContent: 'space-between',
         color: '#EAE8E4',
     },
-
     sectionheaders: {
         fontSize: 12,
         fontWeight: "900",
@@ -140,7 +117,6 @@ const styles = StyleSheet.create({
         marginBottom: 4,
         marginLeft: 8,
     },
-
     categories: {
         paddingLeft: 32,
         fontSize: 10,
@@ -149,29 +125,26 @@ const styles = StyleSheet.create({
         marginBottom: 16,
         width: '75%',
     },
-
     textfields: {
-        height: 40, 
-        width: '75%', 
-        borderColor: '#00274C', 
-        borderWidth: 1, 
+        height: 40,
+        width: '75%',
+        borderColor: '#00274C',
+        borderWidth: 1,
         //backgroundColor: '#D3D3D3', 
-        padding:4,
+        padding: 4,
         textShadowColor: 'rgba(0, 0, 0, 0.75)',
         marginLeft: 8,
     },
-
     categoryfields: {
-        height: 40, 
-        width: '100%', 
-        borderColor: '#00274C', 
-        borderWidth: 1, 
+        height: 40,
+        width: '100%',
+        borderColor: '#00274C',
+        borderWidth: 1,
         //backgroundColor: '#D3D3D3', 
-        padding:4,
+        padding: 4,
         textShadowColor: 'rgba(0, 0, 0, 0.75)',
         marginLeft: 8,
     },
-
     buttonboi: {
         margin: 16,
     }

--- a/src/screens/NewListingScreen.jsx
+++ b/src/screens/NewListingScreen.jsx
@@ -16,10 +16,10 @@ const types = [
     },
     {
         label: "Textbook", value: "textbook", icon: "book", options: [
-            { label: "Mathematics", value: "math", icon: "book-open-page-variant" },
+            { label: "Mathematics", value: "math", icon: "calculator" },
             { label: "History", value: "history", icon: "book-open-page-variant" },
-            { label: "Science", value: "science", icon: "book-open-page-variant" },
-            { label: "Foreign Language", value: "language", icon: "book-open-page-variant" }
+            { label: "Science", value: "science", icon: "flask" },
+            { label: "Foreign Language", value: "language", icon: "earth" }
         ]
     },
     {

--- a/src/screens/NewListingScreen.jsx
+++ b/src/screens/NewListingScreen.jsx
@@ -59,7 +59,7 @@ const NewListingScreen = ({ navigation }) => {
                                     filled
                                     bold
                                     onPress={() =>
-                                        navigation.navigate("Listing Form", { category: cat.value, type: type.value })
+                                        navigation.navigate("Listing Form", { category: cat, type: type.value })
                                     }
                                 />
                             </View>


### PR DESCRIPTION
This PR includes both _integration_ with the backend as well as what is effectively a _proposal_ for a revised "new listing" flow.

**Integration**
The "Post Listing" button is now functional, calling an endpoint on the backend to create the listing. The server should respond affirmatively. There currently isn't any way to verify the successful addition of the listing other than checking the `Listings` MySQL table.

**Flow Changes**
This PR proposes adjusting the "new listing" flow to a two step (two screen) process. On the first screen, the item type/category is selected. Then, the user fills out the name of the item, the price, and any other details about the item. This means that we can adjust the second step to prompt the user for different details depending on what item type/category they select. As an example, "Sublease" allows users to fill out a description, but "Football Ticket" does not.

The "Price" field has also been adjusted to enforce that the input value is actually a price. Ex. `$13` should automatically become `$13.00`,  `$2.3333333` should become `$2.33`, `$.5` should become `$0.50`, etc.

**Mobile vs Web**
The mobile version should include smooth dropdown animations - these won't appear on web.